### PR TITLE
Correct link to socialiteproviders.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Laravel Socialite [Okta] (https://www.okta.com) provider
 </p>
 
 ## ! Deprecated !
-Use this one instead. http://socialiteproviders.github.io/providers/okta/
+Use this one instead. http://socialiteproviders.github.io/providers/okta.html
 
 ## Contents
 


### PR DESCRIPTION
The existing link was broken.  Correct link added.